### PR TITLE
リレー切り詰め残存を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kazaguruma-transit",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kazaguruma-transit",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "funding": [
         "https://ko-fi.com/nawashiro",
         "https://github.com/sponsors/nawashiro"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kazaguruma-transit",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Nawashiro"
   },

--- a/src/lib/discussion/__tests__/discussion-moderation-snapshot.test.ts
+++ b/src/lib/discussion/__tests__/discussion-moderation-snapshot.test.ts
@@ -157,4 +157,45 @@ describe("loadDiscussionModerationSnapshot", () => {
     expect(snapshot.completionReason).toBe("idle-timeout");
     expect(snapshot.approvalState).toBe("unknown");
   });
+
+  it("passes the complete relay candidate sources to the common executor", async () => {
+    const completion = (events: Event[]) => ({
+      events,
+      completionReason: "eose" as const,
+      attemptedRelayUrls: [],
+      successfulEventRelayUrls: [],
+      sourceRelayUrlsByEventId: {},
+      attempts: [],
+    });
+    const mockedExecuteDiscussionRead = jest.mocked(executeDiscussionRead);
+    mockedExecuteDiscussionRead.mockReset().mockResolvedValue(completion([]));
+    const service = { getEventsWithCompletion: jest.fn() };
+    const configured = [
+      "wss://configured-1",
+      "wss://configured-2",
+      "wss://configured-3",
+      "wss://configured-4",
+    ];
+
+    await loadDiscussionModerationSnapshot(
+      service,
+      { relayLimit: 3, idleTimeoutMs: 100, hardTimeoutMs: 300, dedupWindowMs: 0 },
+      {
+        discussionId: "34550:author:topic",
+        hints: ["wss://hint"],
+        recommended: ["wss://recommended"],
+        successful: ["wss://successful"],
+        configured,
+        defaults: ["wss://default"],
+      },
+    );
+
+    expect(mockedExecuteDiscussionRead.mock.calls[0]?.[1].candidates).toEqual({
+      hints: ["wss://hint"],
+      recommended: ["wss://recommended"],
+      successful: ["wss://successful"],
+      configured,
+      defaults: ["wss://default"],
+    });
+  });
 });

--- a/src/lib/discussion/discussion-moderation-snapshot.ts
+++ b/src/lib/discussion/discussion-moderation-snapshot.ts
@@ -2,7 +2,7 @@ import type { DiscussionReadStrategyConfig } from "@/lib/config/discussion-confi
 import { executeDiscussionRead, type DiscussionReadTransport } from "@/lib/discussion/discussion-read-executor";
 import type { DiscussionReadPlan } from "@/lib/discussion/discussion-read-plan";
 import type { CompletionReason, Event, Filter, NostrService } from "@/lib/nostr/nostr-service";
-import { rankRelayCandidates, type RelayCandidate, selectRelayCandidates } from "@/lib/discussion/relay-candidate-selector";
+import { rankRelayCandidates, type RelayCandidate } from "@/lib/discussion/relay-candidate-selector";
 import { isModeratorRequestEvent } from "@/lib/discussion/moderator-request";
 
 export type ApprovalState = "approved" | "unapproved" | "unknown";
@@ -67,9 +67,14 @@ export const loadDiscussionModerationSnapshot = async (
   input: { discussionId: string; hints?: string[]; recommended?: string[]; successful?: string[]; configured: string[]; defaults: string[]; until?: number; primaryTags?: string[] }
 ): Promise<DiscussionModerationSnapshot> => {
   const relayCandidates = rankRelayCandidates(input);
-  const relayUrls = selectRelayCandidates({ ...input, limit: strategy.relayLimit }).map((candidate) => candidate.url);
   const transport: DiscussionReadTransport = (filters, options) => service.getEventsWithCompletion(filters as Filter[], options);
-  const candidates = { configured: relayUrls, defaults: [] };
+  const candidates = {
+    hints: input.hints,
+    recommended: input.recommended,
+    successful: input.successful,
+    configured: input.configured,
+    defaults: input.defaults,
+  };
   const primaryPlan: DiscussionReadPlan = {
     target: "discussion-list",
     filters: [{


### PR DESCRIPTION
1.4.2 で修正したはずでしたが、リレーを3件に切り詰める挙動が残存していました。これを除去しました。