### PR TITLE
fix: npub表示の意味論を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ ko-fi-content.json
 .claude/
 
 # common local/editor artifacts
+/.hermes/
 dist/
 *.tmp
 *.swp

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,11 +1,11 @@
 <!--
 Sync Impact Report:
-- Version Change: 1.9.0 -> 1.10.0
-- Reason: 非典型記法の静的監査スコープを、現行production usageに基づき明文化。
+- Version Change: 1.10.0 -> 1.11.0
+- Reason: タスクリストにサブエージェント委任と実装後レビューを必須化。
 - Modified Principles:
-  * 検証スコープ方針を追加。
+  * 開発ワークフロー
 - Added Sections:
-  * 検証スコープ方針
+  * なし（開発ワークフローに規則を追加）
 - Removed Sections:
   * なし
 - Templates Status:
@@ -198,5 +198,7 @@ Nostr readは`specs/017-discussion-read-executor`を正本とする。詳細は�
 - 機能開発は `dev` から始める。
 - 変更を完了扱いにする前に、`AGENTS.md` に記載された検証コマンドを実行する。
 - Spec Kit を使う場合は、`spec.md`、`plan.md`、`tasks.md`、実装、検証の順で進める。
+- `tasks.md` には、テスト実装・本番実装・レビューをサブエージェントへ委任するタスクを明記する。親エージェントは受入条件、書込境界、検証結果を管理する。
+- `tasks.md` では、テスト実装タスクの直後と本番実装タスクの直後に、それぞれレビュータスクを置く。レビュータスクは対応する実装完了後に実行する。
 
-**Version**: 1.10.0 | **Ratified**: 2026-01-13 | **Last Amended**: 2026-08-16
+**Version**: 1.11.0 | **Ratified**: 2026-01-13 | **Last Amended**: 2026-08-19

--- a/src/components/ui/NpubDisplay.tsx
+++ b/src/components/ui/NpubDisplay.tsx
@@ -25,9 +25,9 @@ export function NpubDisplay({ pubkey }: Props) {
 
   return (
     <div className="flex min-w-0 items-center gap-2">
-      <span className="min-w-0 flex-1 truncate font-mono text-base-content" title={npub}>
+      <code className="min-w-0 flex-1 truncate font-mono text-base-content">
         {npub}
-      </span>
+      </code>
       <button
         type="button"
         onClick={handleCopy}

--- a/src/components/ui/__tests__/NpubDisplay.test.tsx
+++ b/src/components/ui/__tests__/NpubDisplay.test.tsx
@@ -25,6 +25,16 @@ describe("NpubDisplay", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("npub1example");
   });
 
+  it("npub値をcode要素でtitleなしに表示し、truncateとfont-monoを維持する", () => {
+    const npubValue = "npub1already-encoded";
+    render(<NpubDisplay pubkey={npubValue} />);
+
+    const value = screen.getByText(npubValue);
+    expect(value.tagName).toBe("CODE");
+    expect(value).not.toHaveAttribute("title");
+    expect(value).toHaveClass("truncate", "font-mono");
+  });
+
   it("すでにnpub形式のIDを再エンコードしない", () => {
     render(<NpubDisplay pubkey="npub1already-encoded" />);
 


### PR DESCRIPTION
## 概要

Issue #84に対応し、Nostrのnpub表示を機械可読な識別子として意味付けします。

- npub表示を`span`から`code`要素へ変更
- npub値自身の`title`属性を削除
- コピー操作、アクセシブルネーム、44pxタッチ領域、既存のnpub変換を維持
- 回帰テストを追加
- 先行してユーザー依頼で`/.gitignore`に`/.hermes/`を追加し、憲章を`1.11.0`へ更新

## 対応理由

npubは画面上に表示される機械可読な識別子です。表示値を`code`要素として明示し、可視テキストと重複する`title`属性への依存をなくします。

共通コンポーネントを修正するため、`/settings`、モデレーター管理、会話作成・編集などの利用箇所へ一貫して反映されます。

## 検証

- `npm run lint` — exit 0（既存warningあり）
- `npx tsc --noEmit --incremental false` — exit 0
- `npm test` — 129 passed、17 skipped（exit 0）
- `npm run build` — exit 0
- `git diff --check` — 成功
- 対象4 suites — 15 tests passed
- 旧実装に戻した隔離worktreeで、新規回帰テストがREDになることを確認
- テスト実装レビュー、production実装レビューともにfresh read-only reviewerの`VERDICT: PASS`

`npm run build`では、ローカル環境に`transit-config.json`がないためGTFS importが設定読み込みエラーを出しました。ただし既存スクリプトが処理を継続し、Next.jsのproduction buildは成功しています。

## 影響範囲

- UI表示要素のみ変更
- データ形式、認証、Nostrイベント、データベース、GTFSデータは変更なし

Closes #84
